### PR TITLE
Add WeekDays.java: initialize full week, resize to weekdays, and shuffle

### DIFF
--- a/WeekDays.java
+++ b/WeekDays.java
@@ -1,0 +1,35 @@
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+public class WeekDays {
+    public static void main(String[] args) {
+        String[] weekDays = {
+            "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday", "Sunday"
+        };
+
+        System.out.println("All days of the week:");
+        printDays(weekDays);
+
+        // Resize the array to 5 elements and copy only weekdays (Monday to Friday).
+        String[] weekdaysOnly = Arrays.copyOf(weekDays, 5);
+
+        System.out.println("\nWeekdays only:");
+        printDays(weekdaysOnly);
+
+        shuffleDays(weekdaysOnly);
+        System.out.println("\nShuffled weekdays:");
+        printDays(weekdaysOnly);
+    }
+
+    private static void printDays(String[] days) {
+        for (String day : days) {
+            System.out.println(day);
+        }
+    }
+
+    private static void shuffleDays(String[] days) {
+        List<String> dayList = Arrays.asList(days);
+        Collections.shuffle(dayList);
+    }
+}


### PR DESCRIPTION
### Motivation
- Demonstrate Java array initialization with all 7 days, how to resize/copy an array to keep only weekdays, and show a simple shuffle utility as a bonus.

### Description
- Added `WeekDays.java` which creates a `String[] weekDays` with all seven day names and prints them one per line using `printDays`.
- Resizes/copies the array to five elements with `Arrays.copyOf(weekDays, 5)` and includes a comment at the resize step to indicate intent; the shortened array is printed again.
- Added `shuffleDays` which converts the array to a `List` via `Arrays.asList` and randomizes order with `Collections.shuffle`, then prints the shuffled result.
- Committed the new file `WeekDays.java` to the repository.

### Testing
- Compiled and ran the program with `javac WeekDays.java && java WeekDays`, which executed successfully and printed all days, the weekdays-only list, and a shuffled weekdays list.
- No automated unit tests were added for this small example; runtime execution served as the validation step.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699cb0b816a4832db7ac0b4df3dd1419)