### PR TITLE
Add recursive Java solution to print Nth line of Pascal's Triangle

### DIFF
--- a/PascalTriangleRecursive.java
+++ b/PascalTriangleRecursive.java
@@ -1,0 +1,58 @@
+import java.util.Scanner;
+
+/**
+ * Prints the Nth line of Pascal's Triangle using recursion.
+ *
+ * Line numbering is 1-based:
+ * line 1 -> 1
+ * line 2 -> 1 1
+ * line 3 -> 1 2 1
+ */
+public class PascalTriangleRecursive {
+
+    public static void main(String[] args) {
+        Scanner scanner = new Scanner(System.in);
+
+        System.out.print("Enter N (line number): ");
+        int n = scanner.nextInt();
+
+        if (n <= 0) {
+            System.out.println("N must be a positive integer.");
+            return;
+        }
+
+        int[] nthLine = getPascalLine(n);
+        printLine(nthLine);
+    }
+
+    /**
+     * Recursively computes the nth line of Pascal's Triangle.
+     *
+     * @param n line number (1-based)
+     * @return array containing values of the nth line
+     */
+    public static int[] getPascalLine(int n) {
+        if (n == 1) {
+            return new int[] {1};
+        }
+
+        int[] previousLine = getPascalLine(n - 1);
+        int[] currentLine = new int[n];
+
+        currentLine[0] = 1;
+        currentLine[n - 1] = 1;
+
+        for (int i = 1; i < n - 1; i++) {
+            currentLine[i] = previousLine[i - 1] + previousLine[i];
+        }
+
+        return currentLine;
+    }
+
+    private static void printLine(int[] line) {
+        for (int value : line) {
+            System.out.print(value + " ");
+        }
+        System.out.println();
+    }
+}


### PR DESCRIPTION
### Motivation
- Provide a simple recursive implementation that computes and prints the Nth line of Pascal's Triangle using arrays to store each line.
- Meet the requirement that each interior value is the sum of the two values above it and that line numbering is 1-based.
- Include minimal input validation and readable output formatting for interactive use.

### Description
- Add `PascalTriangleRecursive.java` which reads an integer `N` from standard input and validates that `N` is positive.
- Implement `getPascalLine(int n)` as a recursive function with base case `n == 1` returning `{1}` and recursive construction of the current line from the previous line.
- Construct each line in an `int[]` with `1` at the ends and interior values computed by `previousLine[i-1] + previousLine[i]`.
- Add `printLine(int[] line)` to print the computed line values space-separated followed by a newline.

### Testing
- Run `javac PascalTriangleRecursive.java` to compile, which completed successfully.
- Run `printf '6\n' | java PascalTriangleRecursive` which executed and produced the expected 6th line output (`1 5 10 10 5 1`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b2e49f3e00832d866c00255cdaaf11)